### PR TITLE
chore: use pnpm version for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "rs lib",
-    "bump": "npx bumpp",
+    "bump": "pnpm version -m \"release: v%s\"",
     "check": "rs check",
     "dev": "rs lib -w",
     "format": "rs fmt",


### PR DESCRIPTION
## Summary

Use pnpm's built-in version command for release preparation, matching rspack-vue-loader. Replace `npx bumpp` with `pnpm version -m "release: v%s"` to create version commits with the standard release message.